### PR TITLE
speed up manage page. PMT #101570

### DIFF
--- a/smart_sa/intervention/views.py
+++ b/smart_sa/intervention/views.py
@@ -143,7 +143,7 @@ def counselor_landing_page(request):
 @login_required
 def manage_participants(request):
     return dict(participants=Participant.objects.all().order_by("name"),
-                backups=Backup.objects.all().order_by("-created"),
+                backups=Backup.objects.all().order_by("-created")[:20],
                 counselors=User.objects.all().order_by("username"))
 
 


### PR DESCRIPTION
The sheer number of backups that have accumulated in the system are making
the manage page slow to load, causing nginx to time out and 502 sometimes.

There's really no reason admins need direct access to every single backup
file right there. Limiting it to 20 speeds things up and should be
fine. If anyone really needs older backups, we still have them in the
database, so we can get them.