### PR TITLE
Fix javascript-based games

### DIFF
--- a/smart_sa/intervention/tests/test_models.py
+++ b/smart_sa/intervention/tests/test_models.py
@@ -237,7 +237,6 @@ class FullSerializationTest(TestCase):
                     p1 = a1.gamepage_set.all()[pidx]
                     p2 = a2.gamepage_set.all()[pidx]
                     self.assertEquals(p1.index(), p2.index())
-                    print a1.gamepage_set.count()
                     self.assertEquals(p1.page_name(), p2.page_name())
                     self.assertEquals(p1.prev_title(), p2.prev_title())
                     self.assertEquals(p1.next_title(), p2.next_title())

--- a/smart_sa/templates/intervention/game.html
+++ b/smart_sa/templates/intervention/game.html
@@ -17,8 +17,9 @@ setTimeout(logstatus, 0);
 </script>
 {% endif %}
 
+<script type="text/javascript" src="{{STATIC_URL}}js/mochikit/MochiKit/MochiKit.js"></script>
+
 {% compress js %}
-   <script type="text/javascript" src="{{STATIC_URL}}js/mochikit/MochiKit/MochiKit.js"></script>
    <script type="text/javascript" src="{{STATIC_URL}}js/static_auth/local_session.js"></script>    
    <script type="text/javascript" src="{{STATIC_URL}}js/static_auth/intervention_storage.js"></script>    
 {% endcompress %}   


### PR DESCRIPTION
In production, the javascript-based activities are broken and throwing multiple errors. Pulling Mochikit.js out of the compress js block resolves these errors in my local environment. I'm thinking some legacy implementation there does not play nicely with the newer compressor. But, this change could also just have put a band-aid on some non-deterministic script loading issue. Let's see.