### PR TITLE
remove double / from MEDIA_URL. PMT #101789

### DIFF
--- a/smart_sa/settings_production.py
+++ b/smart_sa/settings_production.py
@@ -34,7 +34,7 @@ COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT
 COMPRESS_URL = STATIC_URL
 DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
-MEDIA_URL = S3_URL + '/media/'
+MEDIA_URL = S3_URL + 'media/'
 COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
 AWS_QUERYSTRING_AUTH = False
 


### PR DESCRIPTION
S3/cloudfront refuses to serve files when the path is like '//media/...', not silently ignoring the double slash like nginx/apache.