### PR TITLE
Fix Test Database Access

### DIFF
--- a/smart_sa/settings_shared.py
+++ b/smart_sa/settings_shared.py
@@ -1,22 +1,24 @@
 # Django settings for smart_sa clone - masivukeni2
 import os.path
+import sys
 from ccnmtlsettings.shared import common
 
 project = 'smart_sa'
 base = os.path.dirname(__file__)
 locals().update(common(project=project, base=base))
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'masivukeni2',
-        'HOST': '',
-        'PORT': 5432,
-        'USER': '',
-        'PASSWORD': '',
-        'ATOMIC_REQUESTS': True,
+if 'test' not in sys.argv and 'jenkins' not in sys.argv:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'masivukeni2',
+            'HOST': '',
+            'PORT': 5432,
+            'USER': '',
+            'PASSWORD': '',
+            'ATOMIC_REQUESTS': True,
+        }
     }
-}
 
 MEDIA_URL = '/multimedia/'
 


### PR DESCRIPTION
Fixes build
https://jenkins.ccnmtl.columbia.edu/job/masivukeni/143/console

Root issue is the varying project name (smart_sa) vs database name (masivukeni2) that forces the ccnmtlsettings default database override in settings_shared.py