### PR TITLE
:arrow_up: ccnmtlsettings 0.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,4 +68,4 @@ django-impersonate==0.9.2
 django-waffle==0.11
 django-ga-context==0.1.0
 
-ccnmtlsettings==0.1.5
+ccnmtlsettings==0.1.6

--- a/smart_sa/dashboard/tests/test_views.py
+++ b/smart_sa/dashboard/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
 
 
@@ -5,6 +6,9 @@ class IndexViewTest(TestCase):
     fixtures = ["full_testdb.json"]
 
     def setUp(self):
+        u = User.objects.get(username='testcounselor')
+        u.set_password('test')
+        u.save()
         self.client.login(username='testcounselor', password='test')
 
     def test_index(self):

--- a/smart_sa/intervention/tests/test_views.py
+++ b/smart_sa/intervention/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test import client
 from smart_sa.intervention.models import Intervention, ClientSession
@@ -16,6 +17,9 @@ class InterventionViewTest(TestCase):
 
     def setUp(self):
         self.client = client.Client()
+        u = User.objects.get(username='testcounselor')
+        u.set_password('test')
+        u.save()
         self.client.login(username='testcounselor', password='test')
 
     def test_logged_out_index(self):
@@ -129,6 +133,9 @@ class InterventionAdminViewTest(TestCase):
 
     def setUp(self):
         self.client = client.Client()
+        u = User.objects.get(username='testadmin')
+        u.set_password('test')
+        u.save()
         self.client.login(username='testadmin', password='test')
 
     def test_set_deployment(self):


### PR DESCRIPTION
passwords in fixtures need to be overwritten since 0.1.6 changes the `PASSWORD_HASHERS`