### PR TITLE
pylint/pyflakes cleanup

### DIFF
--- a/smart_sa/assessmentquiz_task/features/quiz-steps.py
+++ b/smart_sa/assessmentquiz_task/features/quiz-steps.py
@@ -13,8 +13,8 @@ def there_is_an_assessmentquiz(self):
 @step('I fill in all (\d)s in the quiz')
 def fill_in_quiz(self, value):
     if not world.using_selenium:
-        assert (False,
-                "this step needs to be implemented for the django test client")
+        assert False, ("this step needs to be implemented for "
+                       "the django test client")
     for i in world.firefox.find_elements_by_tag_name('input'):
         if (i.get_attribute('type') == 'radio' and
                 i.get_attribute('value') == value):
@@ -34,8 +34,8 @@ def i_fill_in_value_for_question_number(step, value, number):
 @step(u"Then I'm asked to answer all the questions")
 def then_i_m_asked_to_enter_all_the_questions(step):
     alert = world.firefox.switch_to_alert()
-    assert (alert.text.startswith("Please answer all the questions"),
-            "Alert text valid")
+    assert alert.text.startswith("Please answer all the questions"), (
+        "Alert text valid")
     alert.accept()
 
 

--- a/smart_sa/dashboard/tests/__init__.py
+++ b/smart_sa/dashboard/tests/__init__.py
@@ -1,3 +1,0 @@
-# flake8: noqa
-from test_views import *
-from test_models import *

--- a/smart_sa/intervention/tests/__init__.py
+++ b/smart_sa/intervention/tests/__init__.py
@@ -1,3 +1,0 @@
-# flake8: noqa
-from test_models import *
-from test_views import *

--- a/smart_sa/lifegoal_task/features/lifegoal-step.py
+++ b/smart_sa/lifegoal_task/features/lifegoal-step.py
@@ -29,9 +29,8 @@ def when_i_enter_value_for_input(step, value, input):
 def then_input_is_value(step, input, value):
     elt = get_input(input)
     actual = elt.get_attribute("value")
-    assert (actual == value,
-            "Expected %s to equal %s. Actually is %s" % (input,
-                                                         value, actual))
+    assert actual == value, (
+        "Expected %s to equal %s. Actually is %s" % (input, value, actual))
 
 
 @step(u'Then I wait (\d+) second')

--- a/smart_sa/pill_game/features/pill-steps.py
+++ b/smart_sa/pill_game/features/pill-steps.py
@@ -70,8 +70,8 @@ def there_is_no_pill_named_name(step, name):
 def there_is_not_an_add_pill_button(step):
     try:
         world.firefox.find_element_by_id('add-a-pill')
-        assert (False,
-                'The Add Pill button should not be displayed in this mode')
+        assert False, (
+            'The Add Pill button should not be displayed in this mode')
     except:
         pass
 
@@ -97,14 +97,13 @@ def when_i_drop_pill_onto_time(step, pill, time):
     # get the draggable span within
     draggable = pill.find_element_by_css_selector(
         "div.pill-image span.draggable")
-    assert (draggable is not None,
-            "This pill is not constructed properly: %s" % pill)
+    assert draggable is not None, (
+        "This pill is not constructed properly: %s" % pill)
 
     bucket = get_bucket(time)
-    assert (
-        bucket is not None,
-        ("Time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert bucket is not None, (
+        "Time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
     action_chains = ActionChains(world.firefox)
     action_chains.drag_and_drop(draggable, bucket).perform()
 
@@ -113,20 +112,18 @@ def when_i_drop_pill_onto_time(step, pill, time):
 def when_i_drop_pill_index_onto_time(step, index, time):
     idx = int(index) - 1
     a = world.firefox.find_elements_by_css_selector('div.pill')
-    assert (
-        len(a) > idx,
+    assert len(a) > idx, (
         "Can't find pill %s as there are only %s pills in the list" % (
             index, len(a)))
     pill = a[idx]
     draggable = pill.find_element_by_css_selector(
         "div.pill-image span.draggable")
-    assert (draggable is not None,
-            "This pill is not constructed properly: %s" % pill)
+    assert draggable is not None, (
+        "This pill is not constructed properly: %s" % pill)
     bucket = get_bucket(time)
-    assert (
-        bucket is not None,
-        ("Time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert bucket is not None, (
+        "Time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
     action_chains = ActionChains(world.firefox)
     action_chains.drag_and_drop(draggable, bucket).perform()
 
@@ -138,23 +135,21 @@ def then_there_is_count_pill_in_time(step, count, pill, time):
     # get the draggable span within
     draggable = pill.find_element_by_css_selector(
         "div.pill-image span.draggable")
-    assert (draggable is not None,
-            "This pill is not constructed properly: %s" % pill)
+    assert draggable is not None, (
+        "This pill is not constructed properly: %s" % pill)
     # get the data-id
     data_id = draggable.get_attribute("data-id")
     bucket = get_bucket(time)
-    assert (
-        bucket is not None,
-        ("Time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert bucket is not None, (
+        "Time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
 
     n = 0
     a = bucket.find_elements_by_css_selector('span.trashable')
     for dropped in a:
         if (data_id == dropped.get_attribute("data-id")):
             n = n + 1
-    assert (
-        n == int(count),
+    assert n == int(count), (
         "Expected %s elements in the %s timeslot, instead it contains %s" % (
             count, time, n))
 
@@ -162,14 +157,12 @@ def then_there_is_count_pill_in_time(step, count, pill, time):
 @step(u'Then there are no pills in "([^"]*)"')
 def then_there_are_no_pills_in_timeslot(step, timeslot):
     bucket = get_bucket(timeslot)
-    assert (
-        bucket is not None,
-        ("Time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert bucket is not None, (
+        "Time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
 
     a = bucket.find_elements_by_css_selector('span.trashable')
-    assert (
-        len(a) == 0,
+    assert len(a) == 0, (
         "Expected no pills in bucket %s, instead it contains %s pills" % (
             bucket, len(a)))
 
@@ -177,14 +170,12 @@ def then_there_are_no_pills_in_timeslot(step, timeslot):
 @step(u'Then there are (\d+) pills in "([^"]*)"')
 def then_there_are_count_pills_in_timeslot(step, count, timeslot):
     bucket = get_bucket(timeslot)
-    assert (
-        bucket is not None,
-        ("Time slot must be specified as day or evening. No time slot "
-         "called %s found" % time))
+    assert bucket is not None, (
+        "Time slot must be specified as day or evening. No time slot "
+        "called %s found" % time)
 
     a = bucket.find_elements_by_css_selector('span.trashable')
-    assert (
-        len(a) == int(count),
+    assert len(a) == int(count), (
         "Expected %s pills in bucket %s, instead it contains %s pills" % (
             count, bucket, len(a)))
 
@@ -196,25 +187,22 @@ def when_i_drag_pill_from_time1_to_time2(step, pill, time1, time2):
     assert pill is not None, "No pill named %s found." % pill
     draggable = pill.find_element_by_css_selector(
         "div.pill-image span.draggable")
-    assert (draggable is not None,
-            "This pill is not constructed properly: %s" % pill)
+    assert draggable is not None, (
+        "This pill is not constructed properly: %s" % pill)
     data_id = draggable.get_attribute("data-id")
     bucket = get_bucket(time1)
-    assert (
-        bucket is not None,
-        ("Source time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert bucket is not None, (
+        "Source time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
     dest = get_bucket(time2)
-    assert (
-        dest is not None,
-        ("Destination time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert dest is not None, (
+        "Destination time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
 
     a = bucket.find_elements_by_css_selector('span.trashable')
-    assert (
-        len(a) > 0,
-        ("Expected at least 1 pill in bucket %s, instead it "
-         "contains %s pills" % (bucket, len(a))))
+    assert len(a) > 0, (
+        "Expected at least 1 pill in bucket %s, instead it "
+        "contains %s pills" % (bucket, len(a)))
     action = False
     for dropped in a:
         if (data_id == dropped.get_attribute("data-id")):
@@ -222,8 +210,7 @@ def when_i_drag_pill_from_time1_to_time2(step, pill, time1, time2):
             action_chains = ActionChains(world.firefox)
             action_chains.drag_and_drop(dropped, dest).perform()
             action = True
-    assert (
-        action,
+    assert action, (
         "No dropped pills named %s found in %s slot" % (pill, time1))
 
 
@@ -234,29 +221,25 @@ def when_i_drag_pill_off_time(step, pill, time):
     assert pill is not None, "No pill named %s found." % (pill)
     draggable = pill.find_element_by_css_selector(
         "div.pill-image span.draggable")
-    assert (draggable is not None,
-            "This pill is not constructed properly: %s" % pill)
+    assert draggable is not None, (
+        "This pill is not constructed properly: %s" % pill)
     data_id = draggable.get_attribute("data-id")
 
     bucket = get_bucket(time)
-    assert (
-        bucket is not None,
-        ("Source time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert bucket is not None, (
+        "Source time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
 
     dest = world.firefox.find_element_by_id('pill-game-container')
-    assert (
-        dest is not None,
-        ("Destination time slot must be specified as day or evening. "
-         "No time slot called %s found" % time))
+    assert dest is not None, (
+        "Destination time slot must be specified as day or evening. "
+        "No time slot called %s found" % time)
 
     a = bucket.find_elements_by_css_selector('span.trashable')
-    assert (
-        len(a) > 0,
-        (
-            "Expected at least 1 pill in bucket %s, "
-            "instead it contains %s pills" % (
-                bucket, len(a))))
+    assert len(a) > 0, (
+        "Expected at least 1 pill in bucket %s, "
+        "instead it contains %s pills" % (
+            bucket, len(a)))
 
     action = False
     for dropped in a:
@@ -266,8 +249,8 @@ def when_i_drag_pill_off_time(step, pill, time):
             action_chains.drag_and_drop(dropped, dest).perform()
             action = True
 
-    assert (action,
-            "No dropped pills named %s found in %s slot" % (pill, time))
+    assert action, "No dropped pills named %s found in %s slot" % (
+        pill, time)
 
 
 @step(u'Specify "([^"]*)" time as "([^"]*)"')
@@ -277,10 +260,9 @@ def specify_timeslot_time_as_time(step, timeslot, time):
         id = "day_pills_time"
     elif timeslot == "evening":
         id = "night_pills_time"
-    assert (
-        id is not None,
-        ("Time slot must be specified as day or evening. "
-         "No time slot called %s found" % timeslot))
+    assert id is not None, (
+        "Time slot must be specified as day or evening. "
+        "No time slot called %s found" % timeslot)
 
     elt = world.firefox.find_element_by_id(id)
     assert elt is not None, "Select element not found %s" % id
@@ -300,34 +282,30 @@ def then_the_timeslot_time_is_time(step, timeslot, time):
         id = "day_pills_time"
     elif timeslot == "evening":
         id = "night_pills_time"
-    assert (
-        id is not None,
-        ("Time slot must be specified as day or evening. "
-         "No time slot called %s found" % timeslot))
+    assert id is not None, (
+        "Time slot must be specified as day or evening. "
+        "No time slot called %s found" % timeslot)
 
     elt = world.firefox.find_element_by_id(id)
     assert elt is not None, "Select element not found %s" % id
 
     value = elt.get_attribute("value")
-    assert (
-        time == value,
-        "%s time expected %s, actual %s" % (timeslot, time, value))
+    assert time == value, "%s time expected %s, actual %s" % (
+        timeslot, time, value)
 
 
 @step(u"Then I'm asked to enter a pill name")
 def then_i_m_asked_to_enter_a_pill_name(step):
     alert = world.firefox.switch_to_alert()
-    assert (
-        alert.text.startswith("Please enter a name for this medication"),
-        "Alert text valid")
+    assert alert.text.startswith(
+        "Please enter a name for this medication"), "Alert text valid"
     alert.accept()
 
 
 @step(u"Then I'm told I can only enter 10 pills")
 def then_i_m_told_i_can_only_enter_10_pills(step):
     alert = world.firefox.switch_to_alert()
-    assert (
-        alert.text.startswith("You can only enter 10 pills"),
+    assert alert.text.startswith("You can only enter 10 pills"), (
         "Alert text valid")
     alert.accept()
 
@@ -342,8 +320,7 @@ def then_i_dismiss_second_dialog(step):
 def when_i_name_pill_index_name(step, index, name):
     idx = int(index) - 1
     a = world.firefox.find_elements_by_css_selector('div.pill')
-    assert (
-        len(a) > idx,
+    assert len(a) > idx, (
         "Can't find pill %s as there are only %s pills in the list" % (
             index, len(a)))
     pill = a[idx]

--- a/smart_sa/problemsolving_game/features/barrier-steps.py
+++ b/smart_sa/problemsolving_game/features/barrier-steps.py
@@ -5,8 +5,8 @@ import time
 @step(u'I toggle personal challenge')
 def i_toggle_personal_challenge(step):
     if not world.using_selenium:
-        assert (False,
-                "this step needs to be implemented for the django test client")
+        assert False, (
+            "this step needs to be implemented for the django test client")
     i = world.firefox.find_element_by_css_selector('input[type="checkbox"]')
     try:
         i.click()
@@ -28,8 +28,8 @@ def when_i_click_the_save_plan_button(step):
 @step(u'I select barrier (\d+)')
 def i_select_barrier(step, barrier):
     if not world.using_selenium:
-        assert (False,
-                "this step needs to be implemented for the django test client")
+        assert False, (
+            "this step needs to be implemented for the django test client")
 
     barrier_idx = int(barrier) - 1  # Assumes 1 based indexing
     elts = world.firefox.find_elements_by_css_selector(
@@ -46,8 +46,8 @@ def i_select_barrier(step, barrier):
 @step(u'Then barrier (\d+) has "([^"]*)"')
 def then_barrier_number_has_state(step, number, state):
     if not world.using_selenium:
-        assert (False,
-                "this step needs to be implemented for the django test client")
+        assert False, (
+            "this step needs to be implemented for the django test client")
 
     barrier_idx = int(number) - 1
     elts = world.firefox.find_elements_by_css_selector(
@@ -63,8 +63,8 @@ def then_barrier_number_has_state(step, number, state):
 @step(u'Then barrier (\d+) does not have "([^"]*)"')
 def then_barrier_number_does_not_have_state(step, number, state):
     if not world.using_selenium:
-        assert (False,
-                "this step needs to be implemented for the django test client")
+        assert False, (
+            "this step needs to be implemented for the django test client")
 
     barrier_idx = int(number) - 1
     elts = world.firefox.find_elements_by_css_selector(
@@ -148,15 +148,15 @@ def then_there_is_an_edit_plan_button(step):
 def then_there_is_no_action_plan_form(step):
     time.sleep(1)
     elt = world.firefox.find_element_by_id('actionplan_form')
-    assert (not elt.is_displayed(),
-            "element #actionplan_form should not be visible")
+    assert not elt.is_displayed(), (
+        "element #actionplan_form should not be visible")
 
 
 @step(u'Then there is an Action Plan form')
 def then_there_is_an_action_plan_form(step):
     elt = world.firefox.find_element_by_id('actionplan_form')
-    assert (elt.is_displayed(),
-            "element #actionplan_form should be visible")
+    assert elt.is_displayed(), (
+        "element #actionplan_form should be visible")
 
 
 @step(u'When I type "([^"]*)" in "([^"]*)"')
@@ -176,16 +176,16 @@ def then_elementId_reads_text(step, elementId, text):
 def then_i_can_specify_my_issue(step):
     elt = world.firefox.find_element_by_css_selector(
         'div.issue-subtext textarea')
-    assert (elt.is_displayed(),
-            "element div.issue-subtext textarea should be visible")
+    assert elt.is_displayed(), (
+        "element div.issue-subtext textarea should be visible")
 
 
 @step(u'Then I cannot specify my issue')
 def then_i_cannot_specify_my_issue(step):
     elt = world.firefox.find_element_by_css_selector(
         'div.issue-subtext textarea')
-    assert (not elt.is_displayed(),
-            "element div.issue-subtext textarea should be invisible")
+    assert not elt.is_displayed(), (
+        "element div.issue-subtext textarea should be invisible")
 
 
 @step(u'Then I specify my issue as "([^"]*)"')

--- a/smart_sa/ssnmtree_game/features/ssnmtree-steps.py
+++ b/smart_sa/ssnmtree_game/features/ssnmtree-steps.py
@@ -5,8 +5,7 @@ import time
 @step('I fill in the SSNM Tree with "([^"]*)"')
 def fill_in_ssnmtree(self, text):
     if not world.using_selenium:
-        assert (  # noqa
-            False,
+        assert False, (
             "this step needs to be implemented for the django test client")
     for i in world.firefox.find_elements_by_tag_name('input'):
         if i.get_attribute('type') == 'text':
@@ -19,8 +18,7 @@ def fill_in_ssnmtree(self, text):
 @step('there is a filled in SSNM Tree with "([^"]*)"')
 def filled_in_ssnmtree(self, text):
     if not world.using_selenium:
-        assert (  # noqa
-            False,
+        assert False, (
             "this step needs to be implemented for the django test client")
     all_filled = True
     assert all_filled
@@ -107,8 +105,7 @@ def then_button_is_selected(step, button):
     if len(elts) != 1:
         # import pdb; pdb.set_trace()
         pass
-    assert (  # noqa
-        len(elts) == 1,
+    assert len(elts) == 1, (
         "There should only be one button selected. There are %s" % len(elts))
 
     if button == "disclosure":


### PR DESCRIPTION
* `assert` is weird and has to be handled differently to avoid "[E]
PYFLAKES:assertion is always true, perhaps remove parentheses?"
messages.
* don't need imports in the `tests/__init__.py` files any more.