### PR TITLE
enable time tracking in practice mode

### DIFF
--- a/smart_sa/templates/intervention/activity.html
+++ b/smart_sa/templates/intervention/activity.html
@@ -10,7 +10,7 @@ var game_variables = {{activity.variables|safe}};
 </script>
 
 {% if activity %}
-{% if not participant.is_practice %}
+
 <script>
 var logstatus = function(e) {
    var xmlHttp = new XMLHttpRequest();
@@ -21,7 +21,7 @@ var logstatus = function(e) {
 };
 setTimeout(logstatus, 0);
 </script>
-{% endif %}
+
 {% endif %}
 
 {% endblock %}

--- a/smart_sa/templates/intervention/game.html
+++ b/smart_sa/templates/intervention/game.html
@@ -4,7 +4,7 @@
 
 {% load participant_status %}
 {% block js %}
-{% if not participant.is_practice %}
+
 <script>
 var logstatus = function(e) {
    var xmlHttp = new XMLHttpRequest();
@@ -15,7 +15,7 @@ var logstatus = function(e) {
 };
 setTimeout(logstatus, 0);
 </script>
-{% endif %}
+
 
 <script type="text/javascript" src="{{STATIC_URL}}js/mochikit/MochiKit/MochiKit.js"></script>
 

--- a/smart_sa/templates/intervention/session.html
+++ b/smart_sa/templates/intervention/session.html
@@ -6,7 +6,7 @@
 
 {% block js %}
 {% if session %}
-{% if not participant.is_practice %}
+
 <script>
 var logstatus = function(e) {
    var xmlHttp = new XMLHttpRequest();
@@ -17,7 +17,7 @@ var logstatus = function(e) {
 };
 setTimeout(logstatus, 0);
 </script>
-{% endif %}
+
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
before, we avoided tracking time on pages during practice mode since the
sessions would just get thrown away.

Now, we want to generate a report at the end of a practice session, so
we need to track this stuff.