### PR TITLE
Use psycopg2 bin to resolve namespace issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.11.11 # pyup: <2.0
 simplejson==3.13.2
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 coverage==4.5.1
 BeautifulSoup==3.2.1
 cssselect==1.0.3


### PR DESCRIPTION
Per this warning: 
```
UserWarning: The psycopg2 wheel package will be
renamed from release 2.8; in order to keep installing from binary please
use "pip install psycopg2-binary" instead. For details see:
<http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```