### PR TITLE
Downgrade to django-storages 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ django-debug-toolbar==4.2.0
 django-markwhat==1.6.2
 django-appconf==1.0.4
 django-compressor>=3.1,<5.0
-django-storages==1.13.2
+django-storages==1.8
 django-cacheds3storage==0.3.0
 django-impersonate==1.9.1
 django-waffle==4.0.0


### PR DESCRIPTION
It looks like smart_sa was actually on a very old version of django-storages.